### PR TITLE
Add init_root_info function to initialize trace information structs.

### DIFF
--- a/blkin-lib/zipkin_c.c
+++ b/blkin-lib/zipkin_c.c
@@ -82,14 +82,18 @@ int blkin_init_new_trace(struct blkin_trace *new_trace, const char *service,
 		goto OUT;
 	}
 	new_trace->name = service;
-	new_trace->info.trace_id = random_big();
-	new_trace->info.span_id = random_big();
-	new_trace->info.parent_span_id = 0;
+	blkin_init_trace_info(&(new_trace->info));
 	new_trace->endpoint = endpoint;
 	res = 0;
 
 OUT:
 	return res;
+}
+
+void blkin_init_trace_info(struct blkin_trace_info *trace_info)
+{
+	trace_info->span_id = trace_info->trace_id = random_big();
+	trace_info->parent_span_id = 0;
 }
 
 int blkin_init_child_info(struct blkin_trace *child,
@@ -288,6 +292,26 @@ int blkin_set_trace_info(struct blkin_trace *trace,
 
 	res = 0;
 	trace->info = *info;
+OUT:
+	return res;
+}
+
+int blkin_set_trace_properties(struct blkin_trace *trace,
+			 const struct blkin_trace_info *info,
+			 const char *name,
+			 const struct blkin_endpoint *endpoint)
+{
+	int res;
+	if ((!trace) || (!info) || (!endpoint) || (!name)){
+		res = -EINVAL;
+		goto OUT;
+	}
+
+	res = 0;
+	trace->info = *info;
+	trace->name = name;
+	trace->endpoint = endpoint;
+
 OUT:
 	return res;
 }

--- a/blkin-lib/zipkin_c.h
+++ b/blkin-lib/zipkin_c.h
@@ -164,6 +164,15 @@ int blkin_init_new_trace(struct blkin_trace *new_trace, const char *name,
 			 const struct blkin_endpoint *endpoint);
 
 /**
+ * Initialize blkin_trace_info for a root span. The new trace will
+ * have no parent so the parent id will be zero, and the id and trace id will
+ * be the same.
+ *
+ * @param trace_info the blkin_trace_info to be initialized
+ */
+void blkin_init_trace_info(struct blkin_trace_info *trace_info);
+
+/**
  * Initialize a blkin_trace as a child of the given parent
  * bkin_trace. The child trace will have the same trace_id, new
  * span_id and parent_span_id its parent's span_id.
@@ -285,6 +294,20 @@ int blkin_get_trace_info(const struct blkin_trace *trace,
 int blkin_set_trace_info(struct blkin_trace *trace,
 			 const struct blkin_trace_info *info);
 
+/**
+ * Set the trace information, name and endpoint of a trace.
+ *
+ * @param trace the trace to which the properties will be assigned
+ * @param info blkin_trace_information with the trace identifiers
+ * @param name span name
+ * @param endpoint associated host
+ *
+ * @returns 0 on success or negative error code
+ */
+int blkin_set_trace_properties(struct blkin_trace *trace,
+			 const struct blkin_trace_info *info,
+			 const char *name,
+			 const struct blkin_endpoint *endpoint);
 
 /**
  * Convert a blkin_trace_info to the packed version.

--- a/blkin-lib/ztracer.hpp
+++ b/blkin-lib/ztracer.hpp
@@ -181,10 +181,7 @@ namespace ZTracer {
 		if (child)
 		    return blkin_init_child_info(this, i, ep, _name.c_str());
 
-		int r = blkin_init_new_trace(this, _name.c_str(), ep);
-		if (r == 0)
-		    set_info(i);
-		return r;
+		return blkin_set_trace_properties(this, i, _name.c_str(), ep);
 	    }
 
 	// Trace assumes that name will be a string literal, and avoids


### PR DESCRIPTION
The init_root_info function can be used from rbd engine or elsewhere to initialize trace information, without having to assign unused endpoints or trace names.

Signed-off-by: Victor Araujo ve.ar91@gmail.com
